### PR TITLE
Add offline Flutter build workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,8 +31,10 @@ jobs:
             build-tools;34.0.0
             platforms;android-34
             cmdline-tools;8.0
-          accept-android-sdk-licenses: "yes"
+          accept-android-sdk-licenses:  true      # ⬅️ boolean, TANPA quote
+          log-accepted-android-sdk-licenses: true
 
+    
       # ---------- Export env & seed Flet cache ----------
       - name: Prepare Flutter for Flet
         run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,8 +32,8 @@ jobs:
             platforms;android-34
             cmdline-tools;latest
 
-      # Expose FLUTTER_ROOT + add bin to PATH and seed cache
-      - name: Export Flutter env & seed Flet cache
+      # Expose FLUTTER_ROOT and seed Flet cache
+      - name: Export Flutter & seed cache
         run: |
           echo "FLUTTER_ROOT=${{ steps.flutter.outputs.CACHE-PATH }}" >> $GITHUB_ENV
           echo "${{ steps.flutter.outputs.CACHE-PATH }}/bin" >> $GITHUB_PATH

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,10 +36,10 @@ jobs:
       # ---------- Export env & seed Flet cache ----------
       - name: Prepare Flutter for Flet
         run: |
-          echo "FLUTTER_ROOT=${{ steps.flutter.outputs.FLUTTER_HOME }}" >> $GITHUB_ENV
-          echo "${{ steps.flutter.outputs.FLUTTER_HOME }}/bin" >> $GITHUB_PATH
+          echo "FLUTTER_ROOT=$FLUTTER_HOME" >> $GITHUB_ENV
+          echo "$FLUTTER_HOME/bin" >> $GITHUB_PATH
           mkdir -p ~/.flet/flutter
-          ln -sfn "${{ steps.flutter.outputs.FLUTTER_HOME }}" ~/.flet/flutter/3.27.4-stable
+          ln -sfn "$FLUTTER_HOME" ~/.flet/flutter/3.27.4-stable
           echo '3.27.4-stable' > ~/.flet/flutter/version
 
       # ---------- Lint & test ----------

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,6 +35,8 @@ jobs:
       # ---------- Export FLUTTER_ROOT, update PATH, seed Flet cache ----------
       - name: Prepare Flutter for Flet
         run: |
+          export FLUTTER_ROOT="${{ steps.flutter.outputs.CACHE-PATH }}"
+          export PATH="${{ steps.flutter.outputs.CACHE-PATH }}/bin:$PATH"
           echo "FLUTTER_ROOT=${{ steps.flutter.outputs.CACHE-PATH }}" >> $GITHUB_ENV
           echo "${{ steps.flutter.outputs.CACHE-PATH }}/bin" >> $GITHUB_PATH
           mkdir -p ~/.flet/flutter

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,59 +1,21 @@
-name: Android Build
-
-on:
-  push:
-    branches: [ work ]
-  pull_request:
+name: build-apk
+on: push
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: ghcr.io/cirruslabs/flutter:3.22.1   # ← image sudah full SDK
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
-        with: { python-version: '3.12' }
-      - run: pip install --upgrade -r requirements.txt packaging
+        with: { python-version: "3.12" }
 
-      # ---------- Flutter SDK ----------
-      - id: flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.27.4'
-          channel: stable
-          cache: true
+      - run: pip install --upgrade "flet[all]" tflite-runtime
 
-      # ---------- Android SDK ----------
-      - uses: android-actions/setup-android@v3
-        with:
-          packages: |
-            platform-tools
-            build-tools;34.0.0
-            platforms;android-34
-            cmdline-tools;latest
-          accept-android-sdk-licenses: true
+      # Build debug APK (offline)
+      - run: flet build apk android --skip-flutter-doctor -v
 
-      - run: sdkmanager --list | head -20
-          log-accepted-android-sdk-licenses: true
-
-    
-      # ---------- Export env & seed Flet cache ----------
-      - name: Prepare Flutter for Flet
-        run: |
-          echo "FLUTTER_ROOT=$FLUTTER_HOME" >> $GITHUB_ENV
-          echo "$FLUTTER_HOME/bin" >> $GITHUB_PATH
-          mkdir -p ~/.flet/flutter
-          ln -sfn "$FLUTTER_HOME" ~/.flet/flutter/3.27.4-stable
-          echo '3.27.4-stable' > ~/.flet/flutter/version
-
-      # ---------- Lint & test ----------
-      - run: ruff check .
-      - run: pytest -q
-
-      # ---------- Build APK (offline) ----------
-      - run: bash scripts/build_apk.sh
-
-      # ---------- Upload artifact ----------
       - uses: actions/upload-artifact@v4
         with:
           name: ErgoMotion-debug-apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,33 @@
+name: Android Build
+
+on:
+  push:
+    branches: [ work ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Python dependencies
+        run: pip install flet ruff pytest
+      - name: Ruff
+        run: ruff .
+      - name: Pytest
+        run: pytest
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.27.4'
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+      - name: Build APK (offline patch)
+        run: bash scripts/build_apk.sh
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: build/app/outputs/flutter-apk/*.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,11 +26,12 @@ jobs:
       # ---------- Android SDK ----------
       - uses: android-actions/setup-android@v3
         with:
-          components: |
+          packages: |
             platform-tools
             build-tools;34.0.0
             platforms;android-34
             cmdline-tools;latest
+          accept-android-sdk-licenses: true
 
       # ---------- Export env & seed Flet cache ----------
       - name: Prepare Flutter for Flet

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,12 +35,10 @@ jobs:
       # ---------- Export FLUTTER_ROOT, update PATH, seed Flet cache ----------
       - name: Prepare Flutter for Flet
         run: |
-          export FLUTTER_ROOT="${{ steps.flutter.outputs.FLUTTER_HOME }}"
-          export PATH="${{ steps.flutter.outputs.FLUTTER_HOME }}/bin:$PATH"
-          echo "FLUTTER_ROOT=${{ steps.flutter.outputs.FLUTTER_HOME }}" >> $GITHUB_ENV
-          echo "${{ steps.flutter.outputs.FLUTTER_HOME }}/bin" >> $GITHUB_PATH
+          echo "FLUTTER_ROOT=${{ steps.flutter.outputs.CACHE-PATH }}" >> $GITHUB_ENV
+          echo "${{ steps.flutter.outputs.CACHE-PATH }}/bin" >> $GITHUB_PATH
           mkdir -p ~/.flet/flutter
-          ln -sfn "${{ steps.flutter.outputs.FLUTTER_HOME }}" ~/.flet/flutter/3.27.4-stable
+          ln -sfn "${{ steps.flutter.outputs.CACHE-PATH }}" ~/.flet/flutter/3.27.4-stable
           echo '3.27.4-stable' > ~/.flet/flutter/version
 
       # ---------- Lint & test ----------

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,24 +10,46 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Install Python dependencies
-        run: pip install flet ruff pytest
-      - name: Ruff
-        run: ruff .
-      - name: Pytest
-        run: pytest
-      - uses: subosito/flutter-action@v2
+        with: { python-version: '3.12' }
+      - run: pip install --upgrade -r requirements.txt packaging
+
+      # ---------- Flutter 3.27.4 ----------
+      - id: flutter
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.27.4'
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-      - name: Build APK (offline patch)
-        run: bash scripts/build_apk.sh
-      - name: Upload APK
-        uses: actions/upload-artifact@v4
+          channel: stable
+
+      # ---------- Android SDK ----------
+      - uses: android-actions/setup-android@v3
         with:
-          name: app-release
-          path: build/app/outputs/flutter-apk/*.apk
+          components: |
+            platform-tools
+            build-tools;34.0.0
+            platforms;android-34
+            cmdline-tools;latest
+
+      # ---------- Expose Flutter & seed cache for Flet ----------
+      - name: Export Flutter & seed cache
+        run: |
+          echo "FLUTTER_ROOT=$FLUTTER_HOME" >> $GITHUB_ENV
+          echo "$FLUTTER_HOME/bin" >> $GITHUB_PATH       # add to PATH
+
+          mkdir -p ~/.flet/flutter
+          ln -sfn "$FLUTTER_HOME" ~/.flet/flutter/3.27.4-stable
+          echo '3.27.4-stable' > ~/.flet/flutter/version
+
+      # ---------- Lint & test ----------
+      - run: ruff check .
+      - run: pytest -q
+
+      # ---------- Build APK offline ----------
+      - run: bash scripts/build_apk.sh
+
+      # ---------- Upload artifact ----------
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ErgoMotion-debug-apk
+          path: build/**/outputs/apk/debug/*.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,7 +15,7 @@ jobs:
         with: { python-version: '3.12' }
       - run: pip install --upgrade -r requirements.txt packaging
 
-      # ---------------- Flutter 3.27.4 ----------------
+      # ---------- Flutter SDK ----------
       - id: flutter
         uses: subosito/flutter-action@v2
         with:
@@ -32,7 +32,7 @@ jobs:
             platforms;android-34
             cmdline-tools;latest
 
-      # ---------- Export FLUTTER_ROOT, update PATH, seed Flet cache ----------
+      # ---------- Export env & seed Flet cache ----------
       - name: Prepare Flutter for Flet
         run: |
           echo "FLUTTER_ROOT=${{ steps.flutter.outputs.FLUTTER_HOME }}" >> $GITHUB_ENV
@@ -45,9 +45,8 @@ jobs:
       - run: ruff check .
       - run: pytest -q
 
-      # Build APK offline
-      - name: Build APK (offline patch)
-        run: bash scripts/build_apk.sh
+      # ---------- Build APK (offline) ----------
+      - run: bash scripts/build_apk.sh
 
       # ---------- Upload artifact ----------
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,8 +30,10 @@ jobs:
             platform-tools
             build-tools;34.0.0
             platforms;android-34
-            cmdline-tools;8.0
-          accept-android-sdk-licenses:  true      # ⬅️ boolean, TANPA quote
+            cmdline-tools;latest
+          accept-android-sdk-licenses: true
+
+      - run: sdkmanager --list | head -20
           log-accepted-android-sdk-licenses: true
 
     

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,10 +35,10 @@ jobs:
       # ---------- Export FLUTTER_ROOT, update PATH, seed Flet cache ----------
       - name: Prepare Flutter for Flet
         run: |
-          echo "FLUTTER_ROOT=${{ steps.flutter.outputs.CACHE-PATH }}" >> $GITHUB_ENV
-          echo "${{ steps.flutter.outputs.CACHE-PATH }}/bin" >> $GITHUB_PATH
+          echo "FLUTTER_ROOT=${{ steps.flutter.outputs.FLUTTER_HOME }}" >> $GITHUB_ENV
+          echo "${{ steps.flutter.outputs.FLUTTER_HOME }}/bin" >> $GITHUB_PATH
           mkdir -p ~/.flet/flutter
-          ln -sfn "${{ steps.flutter.outputs.CACHE-PATH }}" ~/.flet/flutter/3.27.4-stable
+          ln -sfn "${{ steps.flutter.outputs.FLUTTER_HOME }}" ~/.flet/flutter/3.27.4-stable
           echo '3.27.4-stable' > ~/.flet/flutter/version
 
       # ---------- Lint & test ----------

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,12 +35,12 @@ jobs:
       # ---------- Export FLUTTER_ROOT, update PATH, seed Flet cache ----------
       - name: Prepare Flutter for Flet
         run: |
-          export FLUTTER_ROOT="${{ steps.flutter.outputs.CACHE-PATH }}"
-          export PATH="${{ steps.flutter.outputs.CACHE-PATH }}/bin:$PATH"
-          echo "FLUTTER_ROOT=${{ steps.flutter.outputs.CACHE-PATH }}" >> $GITHUB_ENV
-          echo "${{ steps.flutter.outputs.CACHE-PATH }}/bin" >> $GITHUB_PATH
+          export FLUTTER_ROOT="${{ steps.flutter.outputs.FLUTTER_HOME }}"
+          export PATH="${{ steps.flutter.outputs.FLUTTER_HOME }}/bin:$PATH"
+          echo "FLUTTER_ROOT=${{ steps.flutter.outputs.FLUTTER_HOME }}" >> $GITHUB_ENV
+          echo "${{ steps.flutter.outputs.FLUTTER_HOME }}/bin" >> $GITHUB_PATH
           mkdir -p ~/.flet/flutter
-          ln -sfn "${{ steps.flutter.outputs.CACHE-PATH }}" ~/.flet/flutter/3.27.4-stable
+          ln -sfn "${{ steps.flutter.outputs.FLUTTER_HOME }}" ~/.flet/flutter/3.27.4-stable
           echo '3.27.4-stable' > ~/.flet/flutter/version
 
       # ---------- Lint & test ----------

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,7 @@ jobs:
             platforms;android-34
             cmdline-tools;latest
 
-      # Export FLUTTER_ROOT + PATH and seed Flet cache
+      # ---------- Export FLUTTER_ROOT, update PATH, seed Flet cache ----------
       - name: Prepare Flutter for Flet
         run: |
           echo "FLUTTER_ROOT=${{ steps.flutter.outputs.CACHE-PATH }}" >> $GITHUB_ENV

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,8 +30,8 @@ jobs:
             platform-tools
             build-tools;34.0.0
             platforms;android-34
-            cmdline-tools;latest
-          accept-android-sdk-licenses: true
+            cmdline-tools;8.0
+          accept-android-sdk-licenses: "yes"
 
       # ---------- Export env & seed Flet cache ----------
       - name: Prepare Flutter for Flet

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,8 +32,8 @@ jobs:
             platforms;android-34
             cmdline-tools;latest
 
-      # Expose FLUTTER_ROOT and seed Flet cache
-      - name: Export Flutter & seed cache
+      # Export FLUTTER_ROOT + PATH and seed Flet cache
+      - name: Prepare Flutter for Flet
         run: |
           echo "FLUTTER_ROOT=${{ steps.flutter.outputs.CACHE-PATH }}" >> $GITHUB_ENV
           echo "${{ steps.flutter.outputs.CACHE-PATH }}/bin" >> $GITHUB_PATH

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,12 +15,13 @@ jobs:
         with: { python-version: '3.12' }
       - run: pip install --upgrade -r requirements.txt packaging
 
-      # ---------- Flutter 3.27.4 ----------
+      # ---------------- Flutter 3.27.4 ----------------
       - id: flutter
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.27.4'
           channel: stable
+          cache: true
 
       # ---------- Android SDK ----------
       - uses: android-actions/setup-android@v3
@@ -31,22 +32,22 @@ jobs:
             platforms;android-34
             cmdline-tools;latest
 
-      # ---------- Expose Flutter & seed cache for Flet ----------
-      - name: Export Flutter & seed cache
+      # Expose FLUTTER_ROOT + add bin to PATH and seed cache
+      - name: Export Flutter env & seed Flet cache
         run: |
-          echo "FLUTTER_ROOT=$FLUTTER_HOME" >> $GITHUB_ENV
-          echo "$FLUTTER_HOME/bin" >> $GITHUB_PATH       # add to PATH
-
+          echo "FLUTTER_ROOT=${{ steps.flutter.outputs.CACHE-PATH }}" >> $GITHUB_ENV
+          echo "${{ steps.flutter.outputs.CACHE-PATH }}/bin" >> $GITHUB_PATH
           mkdir -p ~/.flet/flutter
-          ln -sfn "$FLUTTER_HOME" ~/.flet/flutter/3.27.4-stable
+          ln -sfn "${{ steps.flutter.outputs.CACHE-PATH }}" ~/.flet/flutter/3.27.4-stable
           echo '3.27.4-stable' > ~/.flet/flutter/version
 
       # ---------- Lint & test ----------
       - run: ruff check .
       - run: pytest -q
 
-      # ---------- Build APK offline ----------
-      - run: bash scripts/build_apk.sh
+      # Build APK offline
+      - name: Build APK (offline patch)
+        run: bash scripts/build_apk.sh
 
       # ---------- Upload artifact ----------
       - uses: actions/upload-artifact@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flet
+ruff
+pytest

--- a/scripts/build_apk.sh
+++ b/scripts/build_apk.sh
@@ -2,10 +2,22 @@
 set -e
 
 python - <<'PY'
-import os, sys, importlib
+import os, sys, importlib, pathlib, shutil
 from packaging.version import Version
 
 sdk = os.environ["FLUTTER_ROOT"]
+
+# Ensure Flet cache points to the workflow Flutter SDK
+cache_dir = pathlib.Path.home() / ".flet" / "flutter"
+cache_dir.mkdir(parents=True, exist_ok=True)
+link = cache_dir / "3.27.4-stable"
+if link.exists() or link.is_symlink():
+    if link.is_symlink() or link.is_file():
+        link.unlink()
+    else:
+        shutil.rmtree(link)
+link.symlink_to(sdk, target_is_directory=True)
+(cache_dir / "version").write_text("3.27.4-stable")
 
 # --- Patch both install_flutter functions so they never download ---
 for mod_name in ("flet_cli.utils.flutter", "flet_cli.commands.build"):

--- a/scripts/build_apk.sh
+++ b/scripts/build_apk.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+python3 - <<'PY'
+import pathlib
+import sys
+
+flutter_version = "3.27.4"
+version_file = pathlib.Path.home() / ".flet" / "flutter" / "version"
+version_file.parent.mkdir(parents=True, exist_ok=True)
+version_file.write_text(flutter_version)
+
+try:
+    import flet.cli.commands.build as build_mod
+    def install_flutter(*args, **kwargs):
+        print("Skipping install_flutter (offline)")
+    if hasattr(build_mod, "install_flutter"):
+        build_mod.install_flutter = install_flutter
+except Exception as e:
+    print("install_flutter patch failed:", e)
+
+from flet.cli import cli
+# Build APK from current directory
+sys.argv = ["flet", "build", "apk", "."]
+cli.main()
+PY
+

--- a/scripts/build_apk.sh
+++ b/scripts/build_apk.sh
@@ -2,25 +2,27 @@
 set -e
 
 python - <<'PY'
-import shutil, os, sys, importlib
+import os, sys, shutil, importlib
 from pathlib import Path
 from packaging.version import Version
 
+# --- Tentukan lokasi SDK ---
 sdk = os.getenv("FLUTTER_ROOT") or os.getenv("FLUTTER_HOME")
 if not sdk:
     bin_flutter = shutil.which("flutter")
     if not bin_flutter:
-        sys.exit("\u274c  Flutter binary not found.")
+        sys.exit("\u274c Flutter binary tidak ditemukan (env & PATH kosong).")
     sdk = str(Path(bin_flutter).resolve().parents[1])
 
-# patch utils.flutter & commands.build so Flet never downloads SDK
-for module_name in ("flet_cli.utils.flutter", "flet_cli.commands.build"):
-    m = importlib.import_module(module_name)
-    m.install_flutter = lambda *_a, **_kw: sdk
-    if hasattr(m, "MINIMAL_FLUTTER_VERSION"):
-        m.MINIMAL_FLUTTER_VERSION = Version("3.27.4")
+# --- Patch Flet supaya tidak download ---
+for mod_name in ("flet_cli.utils.flutter", "flet_cli.commands.build"):
+    mod = importlib.import_module(mod_name)
+    mod.install_flutter = lambda *_a, **_kw: sdk
+    if hasattr(mod, "MINIMAL_FLUTTER_VERSION"):
+        mod.MINIMAL_FLUTTER_VERSION = Version("3.27.4")
 
-# call Flet CLI (skip doctor = no network)
+# --- Jalankan build offline ---
 sys.argv = ["flet", "build", "apk", "android", "--skip-flutter-doctor", "-v"]
 import flet_cli.cli; flet_cli.cli.main()
 PY
+

--- a/scripts/build_apk.sh
+++ b/scripts/build_apk.sh
@@ -2,11 +2,16 @@
 set -e
 
 python - <<'PY'
-import os, sys, importlib
+import shutil, os, sys, importlib
+from pathlib import Path
 from packaging.version import Version
 
 sdk = os.getenv("FLUTTER_ROOT") or os.getenv("FLUTTER_HOME")
-assert sdk, "FLUTTER_ROOT/FLUTTER_HOME envar missing"
+if not sdk:
+    bin_flutter = shutil.which("flutter")
+    if not bin_flutter:
+        sys.exit("\u274c  Flutter binary not found.")
+    sdk = str(Path(bin_flutter).resolve().parents[1])
 
 # patch utils.flutter & commands.build so Flet never downloads SDK
 for module_name in ("flet_cli.utils.flutter", "flet_cli.commands.build"):

--- a/scripts/build_apk.sh
+++ b/scripts/build_apk.sh
@@ -5,8 +5,8 @@ python - <<'PY'
 import os, sys, importlib
 from packaging.version import Version
 
-sdk = os.environ["FLUTTER_ROOT"]  # set by workflow
-assert sdk, "FLUTTER_ROOT envar missing"
+sdk = os.getenv("FLUTTER_ROOT") or os.getenv("FLUTTER_HOME")
+assert sdk, "FLUTTER_ROOT/FLUTTER_HOME envar missing"
 
 # patch utils.flutter & commands.build so Flet never downloads SDK
 for module_name in ("flet_cli.utils.flutter", "flet_cli.commands.build"):

--- a/scripts/build_apk.sh
+++ b/scripts/build_apk.sh
@@ -1,27 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
-python3 - <<'PY'
-import pathlib
-import sys
+python - <<'PY'
+import os, sys, importlib
+from packaging.version import Version
 
-flutter_version = "3.27.4"
-version_file = pathlib.Path.home() / ".flet" / "flutter" / "version"
-version_file.parent.mkdir(parents=True, exist_ok=True)
-version_file.write_text(flutter_version)
+sdk = os.environ["FLUTTER_ROOT"]
 
-try:
-    import flet.cli.commands.build as build_mod
-    def install_flutter(*args, **kwargs):
-        print("Skipping install_flutter (offline)")
-    if hasattr(build_mod, "install_flutter"):
-        build_mod.install_flutter = install_flutter
-except Exception as e:
-    print("install_flutter patch failed:", e)
+# --- Patch both install_flutter functions so they never download ---
+for mod_name in ("flet_cli.utils.flutter", "flet_cli.commands.build"):
+    mod = importlib.import_module(mod_name)
+    mod.install_flutter = lambda *_a, **_kw: sdk
+    if hasattr(mod, "MINIMAL_FLUTTER_VERSION"):
+        mod.MINIMAL_FLUTTER_VERSION = Version("3.27.4")
 
-from flet.cli import cli
-# Build APK from current directory
-sys.argv = ["flet", "build", "apk", "."]
-cli.main()
+# --- Call Flet CLI (skip doctor to stay offline) ---
+sys.argv = ["flet", "build", "apk", "android", "--skip-flutter-doctor", "-v"]
+import flet_cli.cli; flet_cli.cli.main()
 PY
-

--- a/scripts/build_apk.sh
+++ b/scripts/build_apk.sh
@@ -2,31 +2,20 @@
 set -e
 
 python - <<'PY'
-import os, sys, importlib, pathlib, shutil
+import os, sys, importlib
 from packaging.version import Version
 
-sdk = os.environ["FLUTTER_ROOT"]
+sdk = os.environ["FLUTTER_ROOT"]  # set by workflow
+assert sdk, "FLUTTER_ROOT envar missing"
 
-# Ensure Flet cache points to the workflow Flutter SDK
-cache_dir = pathlib.Path.home() / ".flet" / "flutter"
-cache_dir.mkdir(parents=True, exist_ok=True)
-link = cache_dir / "3.27.4-stable"
-if link.exists() or link.is_symlink():
-    if link.is_symlink() or link.is_file():
-        link.unlink()
-    else:
-        shutil.rmtree(link)
-link.symlink_to(sdk, target_is_directory=True)
-(cache_dir / "version").write_text("3.27.4-stable")
+# patch utils.flutter & commands.build so Flet never downloads SDK
+for module_name in ("flet_cli.utils.flutter", "flet_cli.commands.build"):
+    m = importlib.import_module(module_name)
+    m.install_flutter = lambda *_a, **_kw: sdk
+    if hasattr(m, "MINIMAL_FLUTTER_VERSION"):
+        m.MINIMAL_FLUTTER_VERSION = Version("3.27.4")
 
-# --- Patch both install_flutter functions so they never download ---
-for mod_name in ("flet_cli.utils.flutter", "flet_cli.commands.build"):
-    mod = importlib.import_module(mod_name)
-    mod.install_flutter = lambda *_a, **_kw: sdk
-    if hasattr(mod, "MINIMAL_FLUTTER_VERSION"):
-        mod.MINIMAL_FLUTTER_VERSION = Version("3.27.4")
-
-# --- Call Flet CLI (skip doctor to stay offline) ---
+# call Flet CLI (skip doctor = no network)
 sys.argv = ["flet", "build", "apk", "android", "--skip-flutter-doctor", "-v"]
 import flet_cli.cli; flet_cli.cli.main()
 PY


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for Android build
- implement offline build script that patches Flet's install_flutter logic

## Testing
- `ruff check .`
- `pytest -q`
- `bash scripts/build_apk.sh` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68495cf1087483278d53f807ac5f234b